### PR TITLE
feat: implement /verify command for examiners to verify candidates

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -32,7 +32,6 @@ A **Discord bot** designed to simulate a virtual exam system. Built with **Node.
 ### ⏳ In Progress / Planned
 
 - Mark awarding system
-- candidate verification
 - Candidate and examiner profiles
 - leaderboard command
 
@@ -141,7 +140,8 @@ node app.js
 │   │   └── add.js
 │   └── slashCommands/        # Slash (/) commands for Discord
 │       ├── startpaper.js     # Starts an exam session
-│       └── upload.js         # Handles paper upload
+│       ├── upload.js         # Handles paper upload
+│       └── verify.js         # Verifies candidate fairness and they did not cheat
 ├── config.json               # Local bot configuration
 ├── data/
 │   └── state.js              # Temporary app state data

--- a/commands/slashCommands/startpaper.js
+++ b/commands/slashCommands/startpaper.js
@@ -47,7 +47,9 @@ async function handleStartPaper(interaction) {
         components: [buttonsRow],
     });
 
-    await interaction.editReply(`✅ A new channel has been created for this paper session: <#${paperChannel.id}>`);
+    await interaction.editReply(
+        `✅ A new channel has been created for this paper session: <#${paperChannel.id}>`,
+    );
 }
 
 module.exports = {

--- a/commands/slashCommands/verify.js
+++ b/commands/slashCommands/verify.js
@@ -7,7 +7,7 @@ const { getVerifiedEmbed } = require(path.resolve(__dirname, '..', '..', 'utils'
 async function handleVerify(interaction) {
     const channelID = interaction.channel.id;
     const userOption = interaction.options.getUser('user');
-    const key = doubleKeyMaps(userOption.id, channelID)
+    const key = doubleKeyMaps(userOption.id, channelID);
 
     if (!paperChannels.includes(channelID)) {
         return await interaction.reply({
@@ -24,14 +24,14 @@ async function handleVerify(interaction) {
 
     if (examinersMap.get(channelID)?.id === userOption.id) {
         return await interaction.reply({
-            content: '❌ You cannot verify an examiner.'
-        })
+            content: '❌ You cannot verify an examiner.',
+        });
     }
 
     if (verifiedCandidates.get(key)) {
         return await interaction.reply({
-            content: '❌ This candidate is already verified for this session.'
-        })
+            content: '❌ This candidate is already verified for this session.',
+        });
     }
 
     verifiedCandidates.set(key, true);

--- a/commands/slashCommands/verify.js
+++ b/commands/slashCommands/verify.js
@@ -1,10 +1,12 @@
 const path = require('path');
-const { examinersMap, paperChannels } = require(
+const { examinersMap, paperChannels, verifiedCandidates } = require(
     path.resolve(__dirname, '..', '..', 'data', 'state.js'),
 );
 
 async function handleVerify(interaction) {
-    const channelID = interaction.channel.id
+    const channelID = interaction.channel.id;
+    const userOption = interaction.options.getUser("user");
+
     if (!paperChannels.includes(channelID)) {
         return interaction.reply({
             content: '❌ You cannot use this command here.',
@@ -18,8 +20,11 @@ async function handleVerify(interaction) {
         });
     }
 
-    interaction.reply("HELLOW")
-
+    const key = `${userOption.id}::${channelID}`;
+    verifiedCandidates.set(key, true);
+    interaction.reply({
+        content: `${userOption} has been verified. No cheating or unfairness was detected.`
+    });
 }
 
 module.exports = {

--- a/commands/slashCommands/verify.js
+++ b/commands/slashCommands/verify.js
@@ -1,5 +1,5 @@
 const path = require('path');
-const { examinersMap, paperChannels, verifiedCandidates } = require(
+const { examinersMap, paperChannels, verifiedCandidates, doubleKeyMaps } = require(
     path.resolve(__dirname, '..', '..', 'data', 'state.js'),
 );
 const { getVerifiedEmbed } = require(path.resolve(__dirname, '..', '..', 'utils', 'embeds.js'));
@@ -7,6 +7,7 @@ const { getVerifiedEmbed } = require(path.resolve(__dirname, '..', '..', 'utils'
 async function handleVerify(interaction) {
     const channelID = interaction.channel.id;
     const userOption = interaction.options.getUser('user');
+    const key = doubleKeyMaps(userOption.id, channelID)
 
     if (!paperChannels.includes(channelID)) {
         return await interaction.reply({
@@ -27,11 +28,19 @@ async function handleVerify(interaction) {
         })
     }
 
-    const key = `${userOption.id}::${channelID}`;
+    if (verifiedCandidates.get(key)) {
+        return await interaction.reply({
+            content: '❌ This candidate is already verified for this session.'
+        })
+    }
+
     verifiedCandidates.set(key, true);
-    await interaction.reply({
-        content: `${userOption} has been verified. No cheating or unfairness was detected.`,
-    });
+
+    if (verifiedCandidates.get(key)) {
+        await interaction.reply({
+            content: `${userOption} has been verified. No cheating or unfairness was detected.`,
+        });
+    }
 
     const embed = getVerifiedEmbed({
         examiner: interaction.user,
@@ -40,7 +49,6 @@ async function handleVerify(interaction) {
     });
 
     userOption.send({ embeds: [embed] });
-
 }
 
 module.exports = {

--- a/commands/slashCommands/verify.js
+++ b/commands/slashCommands/verify.js
@@ -2,6 +2,7 @@ const path = require('path');
 const { examinersMap, paperChannels, verifiedCandidates } = require(
     path.resolve(__dirname, '..', '..', 'data', 'state.js'),
 );
+const { getVerifiedEmbed } = require(path.resolve(__dirname, '..', '..', 'utils', 'embeds.js'));
 
 async function handleVerify(interaction) {
     const channelID = interaction.channel.id;
@@ -28,9 +29,18 @@ async function handleVerify(interaction) {
 
     const key = `${userOption.id}::${channelID}`;
     verifiedCandidates.set(key, true);
-    interaction.reply({
+    await interaction.reply({
         content: `${userOption} has been verified. No cheating or unfairness was detected.`,
     });
+
+    const embed = getVerifiedEmbed({
+        examiner: interaction.user,
+        channel: interaction.channel,
+        guild: interaction.guild,
+    });
+
+    userOption.send({ embeds: [embed] });
+
 }
 
 module.exports = {

--- a/commands/slashCommands/verify.js
+++ b/commands/slashCommands/verify.js
@@ -1,0 +1,27 @@
+const path = require('path');
+const { examinersMap, paperChannels } = require(
+    path.resolve(__dirname, '..', '..', 'data', 'state.js'),
+);
+
+async function handleVerify(interaction) {
+    const channelID = interaction.channel.id
+    if (!paperChannels.includes(channelID)) {
+        return interaction.reply({
+            content: '❌ You cannot use this command here.',
+            flags: 64,
+        });
+    };
+    if (interaction.user.id !== examinersMap.get(channelID)?.id) {
+        return await interaction.reply({
+            content: '❌ You are not authorized to close this paper session.',
+            flags: 64,
+        });
+    }
+
+    interaction.reply("HELLOW")
+
+}
+
+module.exports = {
+    handleVerify
+};

--- a/commands/slashCommands/verify.js
+++ b/commands/slashCommands/verify.js
@@ -5,14 +5,14 @@ const { examinersMap, paperChannels, verifiedCandidates } = require(
 
 async function handleVerify(interaction) {
     const channelID = interaction.channel.id;
-    const userOption = interaction.options.getUser("user");
+    const userOption = interaction.options.getUser('user');
 
     if (!paperChannels.includes(channelID)) {
         return interaction.reply({
             content: '❌ You cannot use this command here.',
             flags: 64,
         });
-    };
+    }
     if (interaction.user.id !== examinersMap.get(channelID)?.id) {
         return await interaction.reply({
             content: '❌ You are not authorized to close this paper session.',
@@ -23,10 +23,10 @@ async function handleVerify(interaction) {
     const key = `${userOption.id}::${channelID}`;
     verifiedCandidates.set(key, true);
     interaction.reply({
-        content: `${userOption} has been verified. No cheating or unfairness was detected.`
+        content: `${userOption} has been verified. No cheating or unfairness was detected.`,
     });
 }
 
 module.exports = {
-    handleVerify
+    handleVerify,
 };

--- a/commands/slashCommands/verify.js
+++ b/commands/slashCommands/verify.js
@@ -8,16 +8,22 @@ async function handleVerify(interaction) {
     const userOption = interaction.options.getUser('user');
 
     if (!paperChannels.includes(channelID)) {
-        return interaction.reply({
+        return await interaction.reply({
             content: '❌ You cannot use this command here.',
             flags: 64,
         });
     }
     if (interaction.user.id !== examinersMap.get(channelID)?.id) {
         return await interaction.reply({
-            content: '❌ You are not authorized to close this paper session.',
+            content: '❌ You are not authorized to verify candidates in this paper session.',
             flags: 64,
         });
+    }
+
+    if (examinersMap.get(channelID)?.id === userOption.id) {
+        return await interaction.reply({
+            content: '❌ You cannot verify an examiner.'
+        })
     }
 
     const key = `${userOption.id}::${channelID}`;

--- a/data/state.js
+++ b/data/state.js
@@ -14,5 +14,5 @@ module.exports = {
     paperChannels,
     paperTimeMinsMap,
     paperRunningMap,
-    verifiedCandidates
+    verifiedCandidates,
 };

--- a/data/state.js
+++ b/data/state.js
@@ -20,5 +20,5 @@ module.exports = {
     paperTimeMinsMap,
     paperRunningMap,
     verifiedCandidates,
-    doubleKeyMaps
+    doubleKeyMaps,
 };

--- a/data/state.js
+++ b/data/state.js
@@ -6,6 +6,7 @@ const candidatesMap = new Map();
 const paperChannels = [];
 const paperTimeMinsMap = new Map();
 const paperRunningMap = new Map();
+const verifiedCandidates = new Map();
 
 module.exports = {
     examinersMap,
@@ -13,4 +14,5 @@ module.exports = {
     paperChannels,
     paperTimeMinsMap,
     paperRunningMap,
+    verifiedCandidates
 };

--- a/data/state.js
+++ b/data/state.js
@@ -8,6 +8,11 @@ const paperTimeMinsMap = new Map();
 const paperRunningMap = new Map();
 const verifiedCandidates = new Map();
 
+function doubleKeyMaps(firstKey, SecondKey) {
+    const key = `${firstKey}::${SecondKey}`;
+    return key;
+}
+
 module.exports = {
     examinersMap,
     candidatesMap,
@@ -15,4 +20,5 @@ module.exports = {
     paperTimeMinsMap,
     paperRunningMap,
     verifiedCandidates,
+    doubleKeyMaps
 };

--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ const { buttonHandlers } = require('./utils/buttonHandlers');
 const { handleAddCommand } = require('./commands/messageCommands/add');
 const { handleStartPaper } = require('./commands/slashCommands/startpaper');
 const { handleUpload } = require('./commands/slashCommands/upload');
+const { handleVerify } = require('./commands/slashCommands/verify');
 
 const client = new Client({
     intents: [
@@ -42,6 +43,11 @@ client.on(Events.InteractionCreate, async (interaction) => {
     // ───── 📤 UPLOAD PAPER COMMAND ─────
     if (interaction.commandName === 'upload') {
         await handleUpload(interaction);
+    }
+
+    // ───── ✔️ VERIFY PAPER COMMAND ─────
+    if (interaction.commandName === 'verify') {
+        await handleVerify(interaction);
     }
 });
 

--- a/scripts/deploy-commands.js
+++ b/scripts/deploy-commands.js
@@ -36,7 +36,9 @@ const commands = [
 
     new SlashCommandBuilder()
         .setName('verify')
-        .setDescription("Verify the candidate's paper after confirming it was completed fairly and without cheating.")
+        .setDescription(
+            "Verify the candidate's paper after confirming it was completed fairly and without cheating.",
+        )
         .addUserOption((option) =>
             option
                 .setName('user')

--- a/scripts/deploy-commands.js
+++ b/scripts/deploy-commands.js
@@ -33,13 +33,23 @@ const commands = [
                 .setDescription('Attach your solved paper as a PDF file.')
                 .setRequired(true),
         ),
+
+    new SlashCommandBuilder()
+        .setName('verify')
+        .setDescription("Verify the candidate's paper after confirming it was completed fairly and without cheating.")
+        .addUserOption((option) =>
+            option
+                .setName('user')
+                .setDescription('Enter the candidate you want to verify.')
+                .setRequired(true),
+        ),
 ].map((command) => command.toJSON());
 
 const rest = new REST({ version: '10' }).setToken(process.env.TOKEN);
 
 (async () => {
     try {
-        console.log('Registering slash command...');
+        console.log('Registering slash commands...');
 
         await rest.put(
             Routes.applicationGuildCommands(process.env.CLIENT_ID, process.env.GUILD_ID),
@@ -48,8 +58,8 @@ const rest = new REST({ version: '10' }).setToken(process.env.TOKEN);
             },
         );
 
-        console.log('Slash command registered ✅');
+        console.log('Slash commands registered successfully. ✅');
     } catch (err) {
-        console.error('Error registering command:', err);
+        console.error('Error registering commands.', err);
     }
 })();

--- a/utils/embeds.js
+++ b/utils/embeds.js
@@ -35,7 +35,39 @@ function sendExaminerSubmissionEmbed(channelId, candidate, attachment, guild) {
     return embed;
 }
 
+function getVerifiedEmbed({ examiner, channel, guild }) {
+    return new EmbedBuilder()
+        .setColor(0x4ade80) // Green color
+        .setTitle('✅ Candidate Verified')
+        .setDescription(`You have been verified by **${examiner.tag}** for the paper session.`)
+        .addFields(
+            {
+                name: '🧑‍🏫 Examiner',
+                value: `${examiner.tag}`,
+                inline: true,
+            },
+            {
+                name: '🗂️ Session ID (Channel)',
+                value: `[${channel.name}](https://discord.com/channels/${guild.id}/${channel.id})`,
+                inline: true,
+            },
+            {
+                name: '🧾 Server ID',
+                value: `${guild.id}`,
+                inline: true,
+            },
+            {
+                name: '🧾 Paper Channel ID',
+                value: `${channel.id}`,
+                inline: false,
+            }
+        )
+        .setFooter({ text: 'PaperPulseBot • Verification Complete' })
+        .setTimestamp();
+}
+
 module.exports = {
     createPaperEmbed,
     sendExaminerSubmissionEmbed,
+    getVerifiedEmbed
 };

--- a/utils/embeds.js
+++ b/utils/embeds.js
@@ -60,7 +60,7 @@ function getVerifiedEmbed({ examiner, channel, guild }) {
                 name: '🧾 Paper Channel ID',
                 value: `${channel.id}`,
                 inline: false,
-            }
+            },
         )
         .setFooter({ text: 'PaperPulseBot • Verification Complete' })
         .setTimestamp();
@@ -69,5 +69,5 @@ function getVerifiedEmbed({ examiner, channel, guild }) {
 module.exports = {
     createPaperEmbed,
     sendExaminerSubmissionEmbed,
-    getVerifiedEmbed
+    getVerifiedEmbed,
 };


### PR DESCRIPTION
---
This feature introduces a new `/verify` command that allows an **examiner** to verify a candidate after confirming they did not cheat and followed exam guidelines.

* ✅ Implements `doubleKeyMaps()` to support storing and retrieving values with two-part composite keys (`userID::channelID`).
* 🛡️ Adds error handling to prevent verifying a candidate more than once — with clear feedback if already verified.
* 🗂️ Updates internal state tracking using the `verifiedCandidates` map.
* 📩 Sends a confirmation embed to the candidate when they are successfully verified.

This command enhances the integrity and structure of the exam flow by allowing controlled verification through authorized examiners only.

---
