### PR TITLE
Add complete /profile command with "View All Sessions" Button

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -140,6 +140,7 @@ node app.js
 │   │   └── add.js
 │   └── slashCommands/        # Slash (/) commands for Discord
 │       ├── award.js          # Awards marks from examiner to candidate
+│       ├── profile.js        # Slash command to display a candidate's profile summary
 │       ├── startpaper.js     # Starts an exam session
 │       ├── upload.js         # Handles paper upload
 │       └── verify.js         # Verifies candidate fairness and that they did not cheat

--- a/commands/slashCommands/profile.js
+++ b/commands/slashCommands/profile.js
@@ -5,6 +5,8 @@ const { candidateSessionsMap } = require(
     path.resolve(__dirname, '..', '..', 'data', 'state.js'),
 );
 
+const { createProfileCommandButtons } = require(path.resolve(__dirname, '..', '..', 'utils', 'buttons.js'));
+
 async function handleProfile(interaction) {
     let member;
     const userOption = interaction.options.getUser('user');
@@ -28,9 +30,11 @@ async function handleProfile(interaction) {
 
     const embed = generateProfileEmbed(user, member, sessionStats);
 
+    const buttonsRow = createProfileCommandButtons()
+
     await interaction.reply({
         embeds: [embed],
-        // components: [buttonsRow],
+        components: [buttonsRow],
     });
 }
 

--- a/commands/slashCommands/profile.js
+++ b/commands/slashCommands/profile.js
@@ -1,11 +1,11 @@
 const path = require('path');
 const { generateProfileEmbed } = require(path.resolve(__dirname, '..', '..', 'utils', 'embeds.js'));
 
-const { candidateSessionsMap } = require(
-    path.resolve(__dirname, '..', '..', 'data', 'state.js'),
-);
+const { candidateSessionsMap } = require(path.resolve(__dirname, '..', '..', 'data', 'state.js'));
 
-const { createProfileCommandButtons } = require(path.resolve(__dirname, '..', '..', 'utils', 'buttons.js'));
+const { createProfileCommandButtons } = require(
+    path.resolve(__dirname, '..', '..', 'utils', 'buttons.js'),
+);
 
 async function handleProfile(interaction) {
     let member;
@@ -25,12 +25,12 @@ async function handleProfile(interaction) {
         verifiedSessions: countVerifiedSessions(userId),
         averageMarks: calculateAveragePercentage(userId),
         highestMarks: getHighestMarks(userId),
-        recentSession: getMostRecentSession(userId)
+        recentSession: getMostRecentSession(userId),
     };
 
     const embed = generateProfileEmbed(user, member, sessionStats);
 
-    const buttonsRow = createProfileCommandButtons()
+    const buttonsRow = createProfileCommandButtons();
 
     await interaction.reply({
         embeds: [embed],
@@ -112,8 +112,6 @@ function getMostRecentSession(userId) {
     return mostRecentSession;
 }
 
-
-
 module.exports = {
-    handleProfile
-}
+    handleProfile,
+};

--- a/commands/slashCommands/profile.js
+++ b/commands/slashCommands/profile.js
@@ -1,8 +1,106 @@
+const path = require('path');
+const { generateProfileEmbed } = require(path.resolve(__dirname, '..', '..', 'utils', 'embeds.js'));
+
+const { candidateSessionsMap } = require(
+    path.resolve(__dirname, '..', '..', 'data', 'state.js'),
+);
+
 async function handleProfile(interaction) {
+    const user = interaction.user;
+    const member = interaction.member;
+    const userId = user.id;
+
+    const sessionStats = {
+        totalSessions: countSessions(userId),
+        verifiedSessions: countVerifiedSessions(userId),
+        averageMarks: calculateAveragePercentage(userId),
+        highestMarks: getHighestMarks(userId),
+        recentSession: getMostRecentSession(userId)
+    };
+
+    const embed = generateProfileEmbed(user, member, sessionStats);
+    
     await interaction.reply({
-        content: `Profile command is working!`,
+        embeds: [embed],
+        // components: [buttonsRow],
     });
 }
+
+function countVerifiedSessions(userId) {
+    let verifiedCount = 0;
+
+    for (const [key, session] of candidateSessionsMap.entries()) {
+        if (key.startsWith(`${userId}::`) && session.verified) {
+            verifiedCount++;
+        }
+    }
+
+    return verifiedCount;
+}
+
+function countSessions(userId) {
+    let sessionCount = 0;
+    for (const key of candidateSessionsMap.keys()) {
+        if (key.startsWith(`${userId}`)) {
+            sessionCount++;
+        }
+    }
+    return sessionCount;
+}
+
+function calculateAveragePercentage(userId) {
+    let totalEarned = 0;
+    let totalMax = 0;
+
+    for (const [key, session] of candidateSessionsMap.entries()) {
+        if (key.startsWith(`${userId}::`) && typeof session.marks === 'string') {
+            const [earnedStr, maxStr] = session.marks.split('/');
+            const earned = parseFloat(earnedStr);
+            const max = parseFloat(maxStr);
+
+            if (!isNaN(earned) && !isNaN(max) && max > 0) {
+                totalEarned += earned;
+                totalMax += max;
+            }
+        }
+    }
+
+    if (totalMax === 0) return null;
+
+    return ((totalEarned / totalMax) * 100).toFixed(2);
+}
+
+function getHighestMarks(userId) {
+    let highest = 0;
+
+    for (const [key, session] of candidateSessionsMap.entries()) {
+        if (key.startsWith(`${userId}::`) && session.marks) {
+            const [scoredStr] = session.marks.split('/');
+            const scored = parseFloat(scoredStr);
+            if (!isNaN(scored) && scored > highest) {
+                highest = scored;
+            }
+        }
+    }
+
+    return highest;
+}
+
+function getMostRecentSession(userId) {
+    let mostRecentSession = null;
+    let latestTimestamp = 0;
+
+    for (const [key, session] of candidateSessionsMap.entries()) {
+        if (key.startsWith(`${userId}::`) && session.createdAt > latestTimestamp) {
+            latestTimestamp = session.createdAt;
+            mostRecentSession = session;
+        }
+    }
+
+    return mostRecentSession;
+}
+
+
 
 module.exports = {
     handleProfile

--- a/commands/slashCommands/profile.js
+++ b/commands/slashCommands/profile.js
@@ -1,0 +1,9 @@
+async function handleProfile(interaction) {
+    await interaction.reply({
+        content: `Profile command is working!`,
+    });
+}
+
+module.exports = {
+    handleProfile
+}

--- a/commands/slashCommands/profile.js
+++ b/commands/slashCommands/profile.js
@@ -6,9 +6,17 @@ const { candidateSessionsMap } = require(
 );
 
 async function handleProfile(interaction) {
-    const user = interaction.user;
-    const member = interaction.member;
+    let member;
+    const userOption = interaction.options.getUser('user');
+    const user = userOption ?? interaction.user;
     const userId = user.id;
+
+    try {
+        member = await interaction.guild.members.fetch(userId);
+    } catch (err) {
+        console.error('Failed to fetch member:', err);
+        member = null;
+    }
 
     const sessionStats = {
         totalSessions: countSessions(userId),
@@ -19,7 +27,7 @@ async function handleProfile(interaction) {
     };
 
     const embed = generateProfileEmbed(user, member, sessionStats);
-    
+
     await interaction.reply({
         embeds: [embed],
         // components: [buttonsRow],

--- a/data/state.js
+++ b/data/state.js
@@ -21,6 +21,7 @@ function createCandidateSessionEntry(user, message, verified, marks) {
         marks: marks,
         examinerId: examinersMap.get(message.channel.id)?.id || null,
         guildId: message.guild.id,
+        createdAt: Date.now(),
     });
 }
 

--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ const { handleStartPaper } = require('./commands/slashCommands/startpaper');
 const { handleUpload } = require('./commands/slashCommands/upload');
 const { handleVerify } = require('./commands/slashCommands/verify');
 const { handleAward } = require('./commands/slashCommands/award');
+const { handleProfile } = require('./commands/slashCommands/profile');
 
 const client = new Client({
     intents: [
@@ -54,6 +55,11 @@ client.on(Events.InteractionCreate, async (interaction) => {
     // ───── 🏆 AWARD PAPER COMMAND ─────
     if (interaction.commandName === 'award') {
         await handleAward(interaction);
+    }
+
+    // ───── 👤 PROFILE COMMAND ─────
+    if (interaction.commandName === 'profile') {
+        await handleProfile(interaction);
     }
 });
 

--- a/scripts/deploy-commands.js
+++ b/scripts/deploy-commands.js
@@ -61,6 +61,15 @@ const commands = [
                 .setDescription('Enter the awarded marks (e.g., 80/100)')
                 .setRequired(true),
         ),
+    new SlashCommandBuilder()
+        .setName('profile')
+        .setDescription('View the profile of a candidate.')
+        .addUserOption((option) =>
+            option
+                .setName('user')
+                .setDescription('Enter the candidate you want to view profile of.')
+                .setRequired(false),
+        ),
 ].map((command) => command.toJSON());
 
 const rest = new REST({ version: '10' }).setToken(process.env.TOKEN);

--- a/utils/buttonHandlers.js
+++ b/utils/buttonHandlers.js
@@ -46,11 +46,13 @@ async function handleCloseButton(interaction, channelID) {
     interaction.channel.delete();
 }
 
-async function handleViewAllSessions(interaction, _channelID) {
+// eslint-disable-next-line no-unused-vars
+async function handleViewAllSessions(interaction, channelID) {
     const sessions = [];
     const user = interaction.user;
 
     for (const [key, session] of candidateSessionsMap.entries()) {
+        // eslint-disable-next-line no-unused-vars
         const [candidateId, _sessionId] = key.split('::');
         if (candidateId === user.id) {
             sessions.push(session);

--- a/utils/buttonHandlers.js
+++ b/utils/buttonHandlers.js
@@ -44,12 +44,19 @@ async function handleCloseButton(interaction, channelID) {
     interaction.channel.delete();
 }
 
+async function handleViewAllSessions(interaction, channelID) {
+    interaction.reply({
+        content: "Hellow viewing all stats"
+    })
+}
+
 
 
 // 🔧 Maps button IDs to their corresponding handler functions
 const buttonHandlers = {
     done: handleDoneButton,
     close: handleCloseButton,
+    view_sessions: handleViewAllSessions,
     // Add more handlers as needed
 };
 

--- a/utils/buttonHandlers.js
+++ b/utils/buttonHandlers.js
@@ -59,10 +59,9 @@ async function handleViewAllSessions(interaction, channelID) {
     }
 
     const embed = generateAllSessionsEmbed(sessions, user);
-    await interaction.reply({ embeds: [embed], ephemeral: true });
+    await interaction.reply({ embeds: [embed], flags: 64 });
 
 }
-
 
 
 // 🔧 Maps button IDs to their corresponding handler functions

--- a/utils/buttonHandlers.js
+++ b/utils/buttonHandlers.js
@@ -52,7 +52,6 @@ async function handleViewAllSessions(interaction, channelID) {
 
     for (const [key, session] of candidateSessionsMap.entries()) {
         const [candidateId, sessionId] = key.split('::');
-        console.log(`Candidate ID: ${candidateId}, Session ID: ${sessionId}`);
         if (candidateId === user.id) {
             sessions.push(session);
         }

--- a/utils/buttonHandlers.js
+++ b/utils/buttonHandlers.js
@@ -46,12 +46,12 @@ async function handleCloseButton(interaction, channelID) {
     interaction.channel.delete();
 }
 
-async function handleViewAllSessions(interaction, channelID) {
+async function handleViewAllSessions(interaction, _channelID) {
     const sessions = [];
     const user = interaction.user;
 
     for (const [key, session] of candidateSessionsMap.entries()) {
-        const [candidateId, sessionId] = key.split('::');
+        const [candidateId, _sessionId] = key.split('::');
         if (candidateId === user.id) {
             sessions.push(session);
         }

--- a/utils/buttonHandlers.js
+++ b/utils/buttonHandlers.js
@@ -44,6 +44,8 @@ async function handleCloseButton(interaction, channelID) {
     interaction.channel.delete();
 }
 
+
+
 // 🔧 Maps button IDs to their corresponding handler functions
 const buttonHandlers = {
     done: handleDoneButton,

--- a/utils/buttonHandlers.js
+++ b/utils/buttonHandlers.js
@@ -8,6 +8,8 @@ const {
     candidateSessionsMap,
 } = require(path.resolve(__dirname, '..', 'data', 'state.js'));
 
+const { generateAllSessionsEmbed } = require(path.resolve(__dirname, 'embeds.js'));
+
 async function handleDoneButton(interaction, channelID) {
     if (interaction.user.id === examinersMap.get(channelID)?.id) return;
 
@@ -45,9 +47,20 @@ async function handleCloseButton(interaction, channelID) {
 }
 
 async function handleViewAllSessions(interaction, channelID) {
-    interaction.reply({
-        content: "Hellow viewing all stats"
-    })
+    const sessions = [];
+    const user = interaction.user
+
+    for (const [key, session] of candidateSessionsMap.entries()) {
+        const [candidateId, sessionId] = key.split('::');
+        console.log(`Candidate ID: ${candidateId}, Session ID: ${sessionId}`);
+        if (candidateId === user.id) {
+            sessions.push(session);
+        }
+    }
+
+    const embed = generateAllSessionsEmbed(sessions, user);
+    await interaction.reply({ embeds: [embed], ephemeral: true });
+
 }
 
 

--- a/utils/buttonHandlers.js
+++ b/utils/buttonHandlers.js
@@ -48,7 +48,7 @@ async function handleCloseButton(interaction, channelID) {
 
 async function handleViewAllSessions(interaction, channelID) {
     const sessions = [];
-    const user = interaction.user
+    const user = interaction.user;
 
     for (const [key, session] of candidateSessionsMap.entries()) {
         const [candidateId, sessionId] = key.split('::');
@@ -59,9 +59,7 @@ async function handleViewAllSessions(interaction, channelID) {
 
     const embed = generateAllSessionsEmbed(sessions, user);
     await interaction.reply({ embeds: [embed], flags: 64 });
-
 }
-
 
 // 🔧 Maps button IDs to their corresponding handler functions
 const buttonHandlers = {

--- a/utils/buttons.js
+++ b/utils/buttons.js
@@ -23,5 +23,5 @@ function createProfileCommandButtons() {
 
 module.exports = {
     createPaperButtons,
-    createProfileCommandButtons
+    createProfileCommandButtons,
 };

--- a/utils/buttons.js
+++ b/utils/buttons.js
@@ -11,4 +11,17 @@ function createPaperButtons() {
     );
 }
 
-module.exports = { createPaperButtons };
+function createProfileCommandButtons() {
+    const buttonsRow = new ActionRowBuilder().addComponents(
+        new ButtonBuilder()
+            .setCustomId('view_sessions')
+            .setLabel('📘 View All Sessions')
+            .setStyle(ButtonStyle.Primary),
+    );
+    return buttonsRow;
+}
+
+module.exports = {
+    createPaperButtons,
+    createProfileCommandButtons
+};

--- a/utils/embeds.js
+++ b/utils/embeds.js
@@ -86,9 +86,52 @@ function getAwardEmbed({ candidate, examiner, marks, guildId, channelId }) {
         .setTimestamp();
 }
 
+function generateProfileEmbed(user, member, sessionStats) {
+    const {
+        totalSessions,
+        verifiedSessions,
+        averageMarks,
+        highestMarks,
+        recentSession,
+    } = sessionStats;
+
+    const embed = new EmbedBuilder()
+        .setTitle(`📄 Profile: ${user.username}`)
+        .setThumbnail(user.displayAvatarURL({ dynamic: true }))
+        .setColor('#5865F2')
+        .addFields(
+            { name: '🧑‍🎓 Total Sessions Taken', value: `${totalSessions}`, inline: true },
+            { name: '✅ Verified Sessions', value: `${verifiedSessions}`, inline: true },
+            { name: '📊 Average Marks', value: `${averageMarks ?? 'N/A'}`, inline: true },
+            { name: '🏅 Highest Marks', value: `${highestMarks ?? 'N/A'}`, inline: true },
+            { name: '📅 Joined Server', value: `<t:${Math.floor(member.joinedTimestamp / 1000)}:D>`, inline: true },
+            { name: '🆔 User ID', value: `${user.id}`, inline: true },
+            { name: '🔖 Tag', value: `${user.tag}`, inline: true },
+        )
+        .setFooter({ text: 'PaperPulse | Candidate Profile Overview' })
+        .setTimestamp();
+
+    if (recentSession) {
+        embed.addFields({
+            name: '🕓 Most Recent Session',
+            value: [
+                `• **Channel:** <#${recentSession.channelId}>`,
+                `• **Marks:** ${recentSession.marks ?? 'N/A'}`,
+                `• **Verified:** ${recentSession.verified ? 'Yes' : 'No'}`,
+                `• **Examiner:** <@${recentSession.examinerId}>`,
+                `• **Started:** <t:${Math.floor(recentSession.createdAt / 1000)}:R>`,
+            ].join('\n'),
+        });
+    }
+
+    return embed;
+}
+
+
 module.exports = {
     createPaperEmbed,
     sendExaminerSubmissionEmbed,
     getVerifiedEmbed,
     getAwardEmbed,
+    generateProfileEmbed
 };

--- a/utils/embeds.js
+++ b/utils/embeds.js
@@ -128,10 +128,44 @@ function generateProfileEmbed(user, member, sessionStats) {
 }
 
 
+function generateAllSessionsEmbed(sessions, user) {
+    const embed = new EmbedBuilder()
+        .setTitle(`📚 All Sessions: ${user.username}`)
+        .setThumbnail(user.displayAvatarURL({ dynamic: true }))
+        .setColor('#00BFFF')
+        .setFooter({ text: 'PaperPulse | All Sessions Overview' })
+        .setTimestamp();
+
+    if (!sessions.length) {
+        embed.setDescription('No sessions found for this candidate.');
+        return embed;
+    }
+
+    for (const session of sessions) {
+        const created = session.createdAt
+            ? `<t:${Math.floor(session.createdAt / 1000)}:R>`
+            : 'N/A';
+
+        embed.addFields({
+            name: `📝 Session in <#${session.channelId}>`,
+            value: [
+                `• **Marks:** ${session.marks ?? 'N/A'}`,
+                `• **Verified:** ${session.verified ? '✅ Yes' : '❌ No'}`,
+                `• **Examiner:** <@${session.examinerId}>`,
+                `• **Started:** ${created}`,
+            ].join('\n'),
+            inline: false,
+        });
+    }
+
+    return embed;
+}
+
 module.exports = {
     createPaperEmbed,
     sendExaminerSubmissionEmbed,
     getVerifiedEmbed,
     getAwardEmbed,
-    generateProfileEmbed
+    generateProfileEmbed,
+    generateAllSessionsEmbed,
 };

--- a/utils/embeds.js
+++ b/utils/embeds.js
@@ -87,13 +87,8 @@ function getAwardEmbed({ candidate, examiner, marks, guildId, channelId }) {
 }
 
 function generateProfileEmbed(user, member, sessionStats) {
-    const {
-        totalSessions,
-        verifiedSessions,
-        averageMarks,
-        highestMarks,
-        recentSession,
-    } = sessionStats;
+    const { totalSessions, verifiedSessions, averageMarks, highestMarks, recentSession } =
+        sessionStats;
 
     const embed = new EmbedBuilder()
         .setTitle(`📄 Profile: ${user.username}`)
@@ -104,7 +99,11 @@ function generateProfileEmbed(user, member, sessionStats) {
             { name: '✅ Verified Sessions', value: `${verifiedSessions}`, inline: true },
             { name: '📊 Average Marks', value: `${averageMarks ?? 'N/A'}`, inline: true },
             { name: '🏅 Highest Marks', value: `${highestMarks ?? 'N/A'}`, inline: true },
-            { name: '📅 Joined Server', value: `<t:${Math.floor(member.joinedTimestamp / 1000)}:D>`, inline: true },
+            {
+                name: '📅 Joined Server',
+                value: `<t:${Math.floor(member.joinedTimestamp / 1000)}:D>`,
+                inline: true,
+            },
             { name: '🆔 User ID', value: `${user.id}`, inline: true },
             { name: '🔖 Tag', value: `${user.tag}`, inline: true },
         )
@@ -127,7 +126,6 @@ function generateProfileEmbed(user, member, sessionStats) {
     return embed;
 }
 
-
 function generateAllSessionsEmbed(sessions, user) {
     const embed = new EmbedBuilder()
         .setTitle(`📚 All Sessions: ${user.username}`)
@@ -142,9 +140,7 @@ function generateAllSessionsEmbed(sessions, user) {
     }
 
     for (const session of sessions) {
-        const created = session.createdAt
-            ? `<t:${Math.floor(session.createdAt / 1000)}:R>`
-            : 'N/A';
+        const created = session.createdAt ? `<t:${Math.floor(session.createdAt / 1000)}:R>` : 'N/A';
 
         embed.addFields({
             name: `📝 Session in <#${session.channelId}>`,


### PR DESCRIPTION
---

### 📝 **Pull Request Description**

This PR finalizes the `/profile` slash command feature with full functionality and user interaction flow.

#### 🔧 Key Changes:

* Registered and scaffolded the `/profile` command.
* Added session stats display for:

  * Total sessions
  * Verified sessions
  * Average marks
  * Highest marks
  * Most recent session
* Added support for viewing profiles of other users via a `user` option.
* Integrated a **"View All Sessions"** button in the profile embed.
* Handled the button interaction to show all sessions in an ephemeral message.

#### 💡 Misc:

* Used Discord's `flags` to send ephemeral replies for the button.
* Updated `README.md` project structure to reflect the new command.

---