### PR TITLE
feat: implement and document /leaderboard command with scoring logic

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -2,10 +2,6 @@
 
 A **Discord bot** designed to simulate a virtual exam system. Built with **Node.js** and **discord.js**, the bot enables candidates to take timed papers under examiner supervision in a fully automated environment on Discord.
 
-> 🚧 **Under Active Development**
->
-> Features and structure are actively evolving. Expect frequent updates — and note that this README may occasionally be out of date.
-
 ---
 
 ## 🔧 Tech Stack
@@ -17,23 +13,6 @@ A **Discord bot** designed to simulate a virtual exam system. Built with **Node.
 - **CI:** GitHub Actions (ESLint, Prettier)
 - **Code Style:** Prettier
 - **Config:** Local JSON files
-
----
-
-## 🧪 Features
-
-### ✅ Currently Available
-
-- `startpaper` slash command to begin an exam
-- Auto-creation of paper channels under specified category
-- Timer and reminder logic when paper time is up
-- ESLint and Prettier enforced formatting and linting
-
-### ⏳ In Progress / Planned
-
-- leaderboard command
-
-> 🔄 Features evolve as per development and testing feedback.
 
 ---
 

--- a/Readme.md
+++ b/Readme.md
@@ -138,6 +138,7 @@ node app.js
 │   │   └── add.js
 │   └── slashCommands/        # Slash (/) commands for Discord
 │       ├── award.js          # Awards marks from examiner to candidate
+│       ├── leaderboard.js    # Handles /leaderboard command to show top candidates by marks.
 │       ├── profile.js        # Slash command to display a candidate's profile summary
 │       ├── startpaper.js     # Starts an exam session
 │       ├── upload.js         # Handles paper upload

--- a/commands/slashCommands/leaderboard.js
+++ b/commands/slashCommands/leaderboard.js
@@ -8,11 +8,7 @@ async function handleLeaderboard(interaction) {
     const allEntries = [...candidateSessionsMap.values()];
 
     const validEntries = allEntries.filter((entry) => {
-        return (
-            entry.verified &&
-            typeof entry.marks === 'string' &&
-            /^\d+\/\d+$/.test(entry.marks)
-        );
+        return entry.verified && typeof entry.marks === 'string' && /^\d+\/\d+$/.test(entry.marks);
     });
 
     const totals = new Map();
@@ -31,8 +27,9 @@ async function handleLeaderboard(interaction) {
         });
     }
 
-    const leaderboardData = [...totals.values()]
-        .sort((a, b) => (b.scored / b.total) - (a.scored / a.total));
+    const leaderboardData = [...totals.values()].sort(
+        (a, b) => b.scored / b.total - a.scored / a.total,
+    );
 
     const embed = getLeaderboardEmbed(leaderboardData);
 

--- a/commands/slashCommands/leaderboard.js
+++ b/commands/slashCommands/leaderboard.js
@@ -1,0 +1,9 @@
+async function handleLeaderboard(interaction) {
+    interaction.reply({
+        content: "Hello",
+    })
+}
+
+module.exports = {
+    handleLeaderboard,
+};

--- a/commands/slashCommands/leaderboard.js
+++ b/commands/slashCommands/leaderboard.js
@@ -10,7 +10,12 @@ async function handleLeaderboard(interaction) {
     const allEntries = [...candidateSessionsMap.values()];
 
     const validEntries = allEntries.filter((entry) => {
-        return entry.verified && typeof entry.marks === 'string' && /^\d+\/\d+$/.test(entry.marks) && entry.channelId === channelId;
+        return (
+            entry.verified &&
+            typeof entry.marks === 'string' &&
+            /^\d+\/\d+$/.test(entry.marks) &&
+            entry.channelId === channelId
+        );
     });
 
     const totals = new Map();

--- a/commands/slashCommands/leaderboard.js
+++ b/commands/slashCommands/leaderboard.js
@@ -1,7 +1,42 @@
+const path = require('path');
+const { getLeaderboardEmbed } = require(path.resolve(__dirname, '..', '..', 'utils', 'embeds.js'));
+const { candidateSessionsMap } = require(path.resolve(__dirname, '..', '..', 'data', 'state.js'));
+
 async function handleLeaderboard(interaction) {
-    interaction.reply({
-        content: "Hello",
-    })
+    await interaction.deferReply();
+
+    const allEntries = [...candidateSessionsMap.values()];
+
+    const validEntries = allEntries.filter((entry) => {
+        return (
+            entry.verified &&
+            typeof entry.marks === 'string' &&
+            /^\d+\/\d+$/.test(entry.marks)
+        );
+    });
+
+    const totals = new Map();
+
+    for (const entry of validEntries) {
+        const [scored, total] = entry.marks.split('/').map(Number);
+        if (isNaN(scored) || isNaN(total)) continue;
+
+        const user = await interaction.client.users.fetch(entry.userId);
+        const prev = totals.get(user.id) || { username: user.username, scored: 0, total: 0 };
+
+        totals.set(user.id, {
+            username: user.username,
+            scored: prev.scored + scored,
+            total: prev.total + total,
+        });
+    }
+
+    const leaderboardData = [...totals.values()]
+        .sort((a, b) => (b.scored / b.total) - (a.scored / a.total));
+
+    const embed = getLeaderboardEmbed(leaderboardData);
+
+    await interaction.editReply({ embeds: [embed] });
 }
 
 module.exports = {

--- a/commands/slashCommands/leaderboard.js
+++ b/commands/slashCommands/leaderboard.js
@@ -3,12 +3,14 @@ const { getLeaderboardEmbed } = require(path.resolve(__dirname, '..', '..', 'uti
 const { candidateSessionsMap } = require(path.resolve(__dirname, '..', '..', 'data', 'state.js'));
 
 async function handleLeaderboard(interaction) {
+    const channelId = interaction.channel.id;
+
     await interaction.deferReply();
 
     const allEntries = [...candidateSessionsMap.values()];
 
     const validEntries = allEntries.filter((entry) => {
-        return entry.verified && typeof entry.marks === 'string' && /^\d+\/\d+$/.test(entry.marks);
+        return entry.verified && typeof entry.marks === 'string' && /^\d+\/\d+$/.test(entry.marks) && entry.channelId === channelId;
     });
 
     const totals = new Map();

--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ const { handleUpload } = require('./commands/slashCommands/upload');
 const { handleVerify } = require('./commands/slashCommands/verify');
 const { handleAward } = require('./commands/slashCommands/award');
 const { handleProfile } = require('./commands/slashCommands/profile');
+const { handleLeaderboard } = require('./commands/slashCommands/leaderboard');
 
 const client = new Client({
     intents: [
@@ -60,6 +61,11 @@ client.on(Events.InteractionCreate, async (interaction) => {
     // ───── 👤 PROFILE COMMAND ─────
     if (interaction.commandName === 'profile') {
         await handleProfile(interaction);
+    }
+
+    // ───── 📊 LEADERBOARD COMMAND ─────
+    if (interaction.commandName === 'leaderboard') {
+        await handleLeaderboard(interaction);
     }
 });
 

--- a/scripts/deploy-commands.js
+++ b/scripts/deploy-commands.js
@@ -70,6 +70,10 @@ const commands = [
                 .setDescription('Enter the candidate you want to view profile of.')
                 .setRequired(false),
         ),
+    new SlashCommandBuilder()
+        .setName('leaderboard')
+        .setDescription('View the leaderboard of the current channel')
+
 ].map((command) => command.toJSON());
 
 const rest = new REST({ version: '10' }).setToken(process.env.TOKEN);

--- a/scripts/deploy-commands.js
+++ b/scripts/deploy-commands.js
@@ -72,8 +72,7 @@ const commands = [
         ),
     new SlashCommandBuilder()
         .setName('leaderboard')
-        .setDescription('View the leaderboard of the current channel')
-
+        .setDescription('View the leaderboard of the current channel'),
 ].map((command) => command.toJSON());
 
 const rest = new REST({ version: '10' }).setToken(process.env.TOKEN);

--- a/utils/embeds.js
+++ b/utils/embeds.js
@@ -157,6 +157,23 @@ function generateAllSessionsEmbed(sessions, user) {
     return embed;
 }
 
+function getLeaderboardEmbed(leaderboardData) {
+    const leaderboardText = leaderboardData.length
+        ? leaderboardData
+            .map((entry, index) => {
+                const percentage = ((entry.scored / entry.total) * 100).toFixed(1);
+                return `**#${index + 1}** ${entry.username} — **${entry.scored}/${entry.total} marks** (${percentage}%)`;
+            })
+            .join('\n')
+        : '_No verified candidate marks found yet._';
+
+    return new EmbedBuilder()
+        .setTitle('🏆 Leaderboard')
+        .setDescription(`Top candidates ranked by total marks\n\n${leaderboardText}`)
+        .setColor(0xfacc15) // Tailwind yellow-400
+        .setTimestamp();
+}
+
 module.exports = {
     createPaperEmbed,
     sendExaminerSubmissionEmbed,
@@ -164,4 +181,5 @@ module.exports = {
     getAwardEmbed,
     generateProfileEmbed,
     generateAllSessionsEmbed,
+    getLeaderboardEmbed
 };

--- a/utils/embeds.js
+++ b/utils/embeds.js
@@ -160,11 +160,11 @@ function generateAllSessionsEmbed(sessions, user) {
 function getLeaderboardEmbed(leaderboardData) {
     const leaderboardText = leaderboardData.length
         ? leaderboardData
-            .map((entry, index) => {
-                const percentage = ((entry.scored / entry.total) * 100).toFixed(1);
-                return `**#${index + 1}** ${entry.username} — **${entry.scored}/${entry.total} marks** (${percentage}%)`;
-            })
-            .join('\n')
+              .map((entry, index) => {
+                  const percentage = ((entry.scored / entry.total) * 100).toFixed(1);
+                  return `**#${index + 1}** ${entry.username} — **${entry.scored}/${entry.total} marks** (${percentage}%)`;
+              })
+              .join('\n')
         : '_No verified candidate marks found yet._';
 
     return new EmbedBuilder()
@@ -181,5 +181,5 @@ module.exports = {
     getAwardEmbed,
     generateProfileEmbed,
     generateAllSessionsEmbed,
-    getLeaderboardEmbed
+    getLeaderboardEmbed,
 };


### PR DESCRIPTION
---

### 🚀 What’s in this PR?

This PR introduces the **`/leaderboard`** slash command, letting users view ranked exam results based on **verified candidate sessions**. It brings in:

* 🧱 **Command registration & handler scaffolding**
* 📊 Parsing of marks in `scored/total` format with validation
* ➕ Aggregation of user scores across sessions
* 🔍 **Channel-based filtering** to display only relevant entries
* 🧮 Ranking users by **percentage score**
* 🧰 **New utility** `getLeaderboardEmbed()` added in `embeds.js`
* 📚 Updated `README.md` to reflect new command in the project structure
* 🧹 Prettier formatting & cleanup for consistency

---
